### PR TITLE
(#103) Add Shot Maps charts and regression controls

### DIFF
--- a/settings_gui/package-lock.json
+++ b/settings_gui/package-lock.json
@@ -15,7 +15,8 @@
         "ntcore-ts-client": "^3.2.0-beta.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "react-router-dom": "^7.13.0"
+        "react-router-dom": "^7.13.0",
+        "recharts": "^3.8.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -1422,6 +1423,42 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.2",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.2.tgz",
@@ -1779,6 +1816,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1823,6 +1872,69 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1887,6 +1999,12 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.54.0",
@@ -2485,6 +2603,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2501,6 +2740,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2534,6 +2779,16 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -2783,6 +3038,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3003,6 +3264,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3027,6 +3298,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-arrayish": {
@@ -3555,6 +3835,29 @@
       "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
       "license": "MIT"
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -3618,6 +3921,57 @@
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
+      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -3801,6 +4155,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3934,6 +4294,37 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/settings_gui/package.json
+++ b/settings_gui/package.json
@@ -19,7 +19,8 @@
     "ntcore-ts-client": "^3.2.0-beta.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-router-dom": "^7.13.0"
+    "react-router-dom": "^7.13.0",
+    "recharts": "^3.8.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/settings_gui/src/components/shot-maps/ShotMapChart.tsx
+++ b/settings_gui/src/components/shot-maps/ShotMapChart.tsx
@@ -1,0 +1,420 @@
+import { useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Checkbox,
+  FormControlLabel,
+  Paper,
+  Stack,
+  useTheme,
+} from '@mui/material';
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { ShotMapDataPoint } from '../../types/ShotMaps';
+import {
+  buildChartData,
+  buildCubicSeries,
+  buildQuadraticSeries,
+  buildSplineInterpolationSeries,
+  type XYPoint,
+} from '../../utils/shotMapRegression';
+
+interface ShotMapChartProps {
+  chartId: string;
+  rows: ShotMapDataPoint[];
+}
+
+type FitVisibility = {
+  quadratic: boolean;
+  cubic: boolean;
+  spline: boolean;
+};
+
+const DEFAULT_FIT_VISIBILITY: FitVisibility = {
+  quadratic: false,
+  cubic: false,
+  spline: false,
+};
+
+const METRIC_CONFIG = {
+  shooterRPM: {
+    actualKey: 'actualShooterRPM',
+    quadraticKey: 'quadraticShooterRPM',
+    cubicKey: 'cubicShooterRPM',
+    splineKey: 'splineShooterRPM',
+    color: '#1565c0',
+  },
+  hoodAngle: {
+    actualKey: 'actualHoodAngle',
+    quadraticKey: 'quadraticHoodAngle',
+    cubicKey: 'cubicHoodAngle',
+    splineKey: 'splineHoodAngle',
+    color: '#2e7d32',
+  },
+  flightTime: {
+    actualKey: 'actualFlightTime',
+    quadraticKey: 'quadraticFlightTime',
+    cubicKey: 'cubicFlightTime',
+    splineKey: 'splineFlightTime',
+    color: '#ef6c00',
+  },
+} as const;
+
+function toSeries(rows: ShotMapDataPoint[]) {
+  const sortedRows = [...rows].sort((a, b) => a.distance.value - b.distance.value);
+
+  return {
+    shooterRPM: sortedRows.map((row) => ({ x: row.distance.value, y: row.shooterRPM })),
+    hoodAngle: sortedRows.map((row) => ({ x: row.distance.value, y: row.hoodAngle.value })),
+    flightTime: sortedRows.map((row) => ({ x: row.distance.value, y: row.flightTime.value })),
+  } satisfies Record<keyof typeof METRIC_CONFIG, XYPoint[]>;
+}
+
+function formatDistance(value: number) {
+  return Number.isFinite(value) ? value.toFixed(2) : '';
+}
+
+export function ShotMapChart({ chartId, rows }: ShotMapChartProps) {
+  const theme = useTheme();
+  const [fitVisibilityByChart, setFitVisibilityByChart] = useState<Record<string, FitVisibility>>({
+    [chartId]: DEFAULT_FIT_VISIBILITY,
+  });
+  const fitVisibility = fitVisibilityByChart[chartId] ?? DEFAULT_FIT_VISIBILITY;
+
+  const { chartData, hasData, xDomain } = useMemo(() => {
+    const series = toSeries(rows);
+    const distances = rows.map((row) => row.distance.value).filter(Number.isFinite);
+    const minDistance = distances.length > 0 ? Math.min(...distances) : 0;
+    const maxDistance = distances.length > 0 ? Math.max(...distances) : 0;
+    const computedDomain: [number, number] =
+      Math.abs(maxDistance - minDistance) < 1e-10
+        ? [Math.max(0, minDistance - 0.25), maxDistance + 0.25]
+        : [Math.max(0, minDistance), maxDistance];
+
+    const fitSeries = {
+      [METRIC_CONFIG.shooterRPM.quadraticKey]: buildQuadraticSeries(series.shooterRPM),
+      [METRIC_CONFIG.shooterRPM.cubicKey]: buildCubicSeries(series.shooterRPM),
+      [METRIC_CONFIG.shooterRPM.splineKey]: buildSplineInterpolationSeries(series.shooterRPM),
+      [METRIC_CONFIG.hoodAngle.quadraticKey]: buildQuadraticSeries(series.hoodAngle),
+      [METRIC_CONFIG.hoodAngle.cubicKey]: buildCubicSeries(series.hoodAngle),
+      [METRIC_CONFIG.hoodAngle.splineKey]: buildSplineInterpolationSeries(series.hoodAngle),
+      [METRIC_CONFIG.flightTime.quadraticKey]: buildQuadraticSeries(series.flightTime),
+      [METRIC_CONFIG.flightTime.cubicKey]: buildCubicSeries(series.flightTime),
+      [METRIC_CONFIG.flightTime.splineKey]: buildSplineInterpolationSeries(series.flightTime),
+    };
+
+    const actualSeries = {
+      [METRIC_CONFIG.shooterRPM.actualKey]: series.shooterRPM,
+      [METRIC_CONFIG.hoodAngle.actualKey]: series.hoodAngle,
+      [METRIC_CONFIG.flightTime.actualKey]: series.flightTime,
+    };
+
+    return {
+      chartData: buildChartData(actualSeries, fitSeries),
+      hasData: rows.length > 0,
+      xDomain: computedDomain,
+    };
+  }, [rows]);
+
+  if (!hasData) {
+    return (
+      <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+        <Alert severity="info">Add or load data points to see the chart and regression overlays.</Alert>
+      </Paper>
+    );
+  }
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+      <Box sx={{ width: '100%', height: { xs: 380, md: 460 } }}>
+        <ResponsiveContainer>
+          <LineChart
+            data={chartData}
+            margin={{ top: 12, right: 24, bottom: 28, left: 24 }}
+          >
+            <CartesianGrid stroke={theme.palette.divider} strokeDasharray="3 3" />
+            <XAxis
+              type="number"
+              dataKey="distance"
+              domain={xDomain}
+              tickFormatter={formatDistance}
+              label={{ value: 'Distance (m)', position: 'insideBottom', offset: -8 }}
+            />
+            <YAxis
+              yAxisId="rpm"
+              orientation="left"
+              width={80}
+              axisLine={{ stroke: METRIC_CONFIG.shooterRPM.color }}
+              tickLine={{ stroke: METRIC_CONFIG.shooterRPM.color }}
+              tick={{ fill: METRIC_CONFIG.shooterRPM.color }}
+              tickFormatter={(value: number) => value.toFixed(0)}
+              label={{
+                value: 'Shooter RPM',
+                angle: -90,
+                position: 'insideLeft',
+                dx: 15,
+                fill: METRIC_CONFIG.shooterRPM.color,
+              }}
+            />
+            <YAxis
+              yAxisId="hood"
+              orientation="left"
+              width={96}
+              axisLine={{ stroke: METRIC_CONFIG.hoodAngle.color }}
+              tickLine={{ stroke: METRIC_CONFIG.hoodAngle.color }}
+              tick={{ fill: METRIC_CONFIG.hoodAngle.color }}
+              tickFormatter={(value: number) => value.toFixed(1)}
+              label={{
+                value: 'Hood Angle (deg)',
+                angle: -90,
+                position: 'insideLeft',
+                dx: 30,
+                fill: METRIC_CONFIG.hoodAngle.color,
+              }}
+            />
+            <YAxis
+              yAxisId="flightTime"
+              orientation="right"
+              width={76}
+              axisLine={{ stroke: METRIC_CONFIG.flightTime.color }}
+              tickLine={{ stroke: METRIC_CONFIG.flightTime.color }}
+              tick={{ fill: METRIC_CONFIG.flightTime.color }}
+              tickFormatter={(value: number) => value.toFixed(2)}
+              label={{
+                value: 'Flight Time (s)',
+                angle: 90,
+                position: 'insideRight',
+                fill: METRIC_CONFIG.flightTime.color,
+                dx: -15
+              }}
+            />
+            <Tooltip
+              labelFormatter={(value) => `Distance: ${formatDistance(Number(value))} m`}
+            />
+            <Legend wrapperStyle={{ paddingTop: 8, transform: 'translateY(4px)' }} />
+
+            <Line
+              yAxisId="rpm"
+              type="linear"
+              dataKey={METRIC_CONFIG.shooterRPM.actualKey}
+              name="Shooter RPM"
+              stroke={METRIC_CONFIG.shooterRPM.color}
+              strokeWidth={3}
+              dot={{ r: 4 }}
+              connectNulls
+              isAnimationActive={false}
+            />
+            {fitVisibility.quadratic && (
+              <Line
+                yAxisId="rpm"
+                type="linear"
+                dataKey={METRIC_CONFIG.shooterRPM.quadraticKey}
+                name="Shooter RPM Quadratic Fit"
+                stroke={METRIC_CONFIG.shooterRPM.color}
+                strokeDasharray="6 4"
+                dot={false}
+                connectNulls
+                isAnimationActive={false}
+              />
+            )}
+            {fitVisibility.cubic && (
+              <Line
+                yAxisId="rpm"
+                type="linear"
+                dataKey={METRIC_CONFIG.shooterRPM.cubicKey}
+                name="Shooter RPM Cubic Fit"
+                stroke={METRIC_CONFIG.shooterRPM.color}
+                strokeDasharray="2 4"
+                dot={false}
+                connectNulls
+                isAnimationActive={false}
+                strokeOpacity={0.8}
+              />
+            )}
+            {fitVisibility.spline && (
+              <Line
+                yAxisId="rpm"
+                type="linear"
+                dataKey={METRIC_CONFIG.shooterRPM.splineKey}
+                name="Shooter RPM Spline"
+                stroke={METRIC_CONFIG.shooterRPM.color}
+                strokeDasharray="12 4"
+                dot={false}
+                connectNulls
+                isAnimationActive={false}
+                strokeOpacity={0.7}
+              />
+            )}
+
+            <Line
+              yAxisId="hood"
+              type="linear"
+              dataKey={METRIC_CONFIG.hoodAngle.actualKey}
+              name="Hood Angle"
+              stroke={METRIC_CONFIG.hoodAngle.color}
+              strokeWidth={3}
+              dot={{ r: 4 }}
+              connectNulls
+              isAnimationActive={false}
+            />
+            {fitVisibility.quadratic && (
+              <Line
+                yAxisId="hood"
+                type="linear"
+                dataKey={METRIC_CONFIG.hoodAngle.quadraticKey}
+                name="Hood Angle Quadratic Fit"
+                stroke={METRIC_CONFIG.hoodAngle.color}
+                strokeDasharray="6 4"
+                dot={false}
+                connectNulls
+                isAnimationActive={false}
+              />
+            )}
+            {fitVisibility.cubic && (
+              <Line
+                yAxisId="hood"
+                type="linear"
+                dataKey={METRIC_CONFIG.hoodAngle.cubicKey}
+                name="Hood Angle Cubic Fit"
+                stroke={METRIC_CONFIG.hoodAngle.color}
+                strokeDasharray="2 4"
+                dot={false}
+                connectNulls
+                isAnimationActive={false}
+                strokeOpacity={0.8}
+              />
+            )}
+            {fitVisibility.spline && (
+              <Line
+                yAxisId="hood"
+                type="linear"
+                dataKey={METRIC_CONFIG.hoodAngle.splineKey}
+                name="Hood Angle Spline"
+                stroke={METRIC_CONFIG.hoodAngle.color}
+                strokeDasharray="12 4"
+                dot={false}
+                connectNulls
+                isAnimationActive={false}
+                strokeOpacity={0.7}
+              />
+            )}
+
+            <Line
+              yAxisId="flightTime"
+              type="linear"
+              dataKey={METRIC_CONFIG.flightTime.actualKey}
+              name="Flight Time"
+              stroke={METRIC_CONFIG.flightTime.color}
+              strokeWidth={3}
+              dot={{ r: 4 }}
+              connectNulls
+              isAnimationActive={false}
+            />
+            {fitVisibility.quadratic && (
+              <Line
+                yAxisId="flightTime"
+                type="linear"
+                dataKey={METRIC_CONFIG.flightTime.quadraticKey}
+                name="Flight Time Quadratic Fit"
+                stroke={METRIC_CONFIG.flightTime.color}
+                strokeDasharray="6 4"
+                dot={false}
+                connectNulls
+                isAnimationActive={false}
+              />
+            )}
+            {fitVisibility.cubic && (
+              <Line
+                yAxisId="flightTime"
+                type="linear"
+                dataKey={METRIC_CONFIG.flightTime.cubicKey}
+                name="Flight Time Cubic Fit"
+                stroke={METRIC_CONFIG.flightTime.color}
+                strokeDasharray="2 4"
+                dot={false}
+                connectNulls
+                isAnimationActive={false}
+                strokeOpacity={0.8}
+              />
+            )}
+            {fitVisibility.spline && (
+              <Line
+                yAxisId="flightTime"
+                type="linear"
+                dataKey={METRIC_CONFIG.flightTime.splineKey}
+                name="Flight Time Spline"
+                stroke={METRIC_CONFIG.flightTime.color}
+                strokeDasharray="12 4"
+                dot={false}
+                connectNulls
+                isAnimationActive={false}
+                strokeOpacity={0.7}
+              />
+            )}
+          </LineChart>
+        </ResponsiveContainer>
+      </Box>
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1} sx={{ mt: 2 }}>
+        <FormControlLabel
+          control={(
+            <Checkbox
+              checked={fitVisibility.quadratic}
+              onChange={(event) =>
+                setFitVisibilityByChart((current) => ({
+                  ...current,
+                  [chartId]: {
+                    ...fitVisibility,
+                    quadratic: event.target.checked,
+                  },
+                }))
+              }
+            />
+          )}
+          label="Show Quadratic Fit"
+        />
+        <FormControlLabel
+          control={(
+            <Checkbox
+              checked={fitVisibility.cubic}
+              onChange={(event) =>
+                setFitVisibilityByChart((current) => ({
+                  ...current,
+                  [chartId]: {
+                    ...fitVisibility,
+                    cubic: event.target.checked,
+                  },
+                }))
+              }
+            />
+          )}
+          label="Show Cubic Fit"
+        />
+        <FormControlLabel
+          control={(
+            <Checkbox
+              checked={fitVisibility.spline}
+              onChange={(event) =>
+                setFitVisibilityByChart((current) => ({
+                  ...current,
+                  [chartId]: {
+                    ...fitVisibility,
+                    spline: event.target.checked,
+                  },
+                }))
+              }
+            />
+          )}
+          label="Show Spline Fit"
+        />
+      </Stack>
+    </Paper>
+  );
+}

--- a/settings_gui/src/pages/ShotMapsEditor.tsx
+++ b/settings_gui/src/pages/ShotMapsEditor.tsx
@@ -4,12 +4,14 @@ import {
   Button,
   IconButton,
   Paper,
+  Tab,
   Table,
   TableBody,
   TableCell,
   TableContainer,
   TableHead,
   TableRow,
+  Tabs,
   TextField,
   Typography,
   Alert,
@@ -27,6 +29,7 @@ import { useConnection } from '../contexts/ConnectionContext';
 import { getData, putData, postData, saveLocal, loadLocal } from '../services/api';
 import type { ShotMaps, ShotMapDataPoint } from '../types/ShotMaps';
 import { shotMapsLocalSignal } from '../services/shotMapsStore';
+import { ShotMapChart } from '../components/shot-maps/ShotMapChart';
 
 function defaultDataPoint(): ShotMapDataPoint {
   return {
@@ -163,6 +166,7 @@ export function ShotMapsEditor() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [snack, setSnack] = useState<{ message: string; severity: 'success' | 'error' } | null>(null);
+  const [activeTab, setActiveTab] = useState<'hub' | 'pass'>('hub');
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -247,6 +251,20 @@ export function ShotMapsEditor() {
     );
   }
 
+  const activeConfig = activeTab === 'hub'
+    ? {
+        chartId: 'hub',
+        title: 'Hub Data Points',
+        rows: data.hubDataPoints,
+        onChange: (rows: ShotMapDataPoint[]) => setData({ ...data, hubDataPoints: rows }),
+      }
+    : {
+        chartId: 'pass',
+        title: 'Pass Data Points',
+        rows: data.passDataPoints,
+        onChange: (rows: ShotMapDataPoint[]) => setData({ ...data, passDataPoints: rows }),
+      };
+
   return (
     <Box>
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 2, gap: 2 }}>
@@ -274,16 +292,23 @@ export function ShotMapsEditor() {
 
       {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
 
-      <DataPointTable
-        title="Hub Data Points"
-        rows={data.hubDataPoints}
-        onChange={(hubDataPoints) => setData({ ...data, hubDataPoints })}
-      />
+      <Paper variant="outlined" sx={{ mb: 2 }}>
+        <Tabs
+          value={activeTab}
+          onChange={(_, value: 'hub' | 'pass') => setActiveTab(value)}
+          variant="fullWidth"
+        >
+          <Tab value="hub" label="Hub Data Points" />
+          <Tab value="pass" label="Pass Data Points" />
+        </Tabs>
+      </Paper>
+
+      <ShotMapChart chartId={activeConfig.chartId} rows={activeConfig.rows} />
 
       <DataPointTable
-        title="Pass Data Points"
-        rows={data.passDataPoints}
-        onChange={(passDataPoints) => setData({ ...data, passDataPoints })}
+        title={activeConfig.title}
+        rows={activeConfig.rows}
+        onChange={activeConfig.onChange}
       />
 
       {data.mechanismCompensationDelay !== undefined && (

--- a/settings_gui/src/pages/VisionEditor.tsx
+++ b/settings_gui/src/pages/VisionEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import {
   Accordion,
   AccordionDetails,
@@ -191,7 +191,7 @@ function GainConstantsSection({ gain, onChange }: GainConstantsSectionProps) {
       </Typography>
       <Grid container spacing={2}>
         {gainFields.map(({ key, label }) => (
-          <Grid item xs={12} sm={6} key={key}>
+          <Grid size={{ xs: 12, sm: 6 }} key={key}>
             <TextField
               type="number"
               size="small"

--- a/settings_gui/src/utils/shotMapRegression.ts
+++ b/settings_gui/src/utils/shotMapRegression.ts
@@ -1,0 +1,264 @@
+export interface XYPoint {
+  x: number;
+  y: number;
+}
+
+export interface ChartPoint {
+  distance: number;
+  [key: string]: number | null;
+}
+
+interface SplineSegment {
+  x0: number;
+  x1: number;
+  a: number;
+  b: number;
+  c: number;
+  d: number;
+}
+
+function collapseDuplicateX(points: XYPoint[]): XYPoint[] {
+  const buckets = new Map<number, { sum: number; count: number }>();
+
+  for (const point of points) {
+    const bucket = buckets.get(point.x);
+    if (bucket) {
+      bucket.sum += point.y;
+      bucket.count += 1;
+    } else {
+      buckets.set(point.x, { sum: point.y, count: 1 });
+    }
+  }
+
+  return [...buckets.entries()]
+    .map(([x, bucket]) => ({ x, y: bucket.sum / bucket.count }))
+    .sort((a, b) => a.x - b.x);
+}
+
+function solveLinearSystem(matrix: number[][], values: number[]): number[] | null {
+  const size = values.length;
+  const augmented = matrix.map((row, index) => [...row, values[index]]);
+
+  for (let pivot = 0; pivot < size; pivot += 1) {
+    let maxRow = pivot;
+    for (let row = pivot + 1; row < size; row += 1) {
+      if (Math.abs(augmented[row][pivot]) > Math.abs(augmented[maxRow][pivot])) {
+        maxRow = row;
+      }
+    }
+
+    if (Math.abs(augmented[maxRow][pivot]) < 1e-10) {
+      return null;
+    }
+
+    if (maxRow !== pivot) {
+      [augmented[pivot], augmented[maxRow]] = [augmented[maxRow], augmented[pivot]];
+    }
+
+    const divisor = augmented[pivot][pivot];
+    for (let column = pivot; column <= size; column += 1) {
+      augmented[pivot][column] /= divisor;
+    }
+
+    for (let row = 0; row < size; row += 1) {
+      if (row === pivot) {
+        continue;
+      }
+
+      const factor = augmented[row][pivot];
+      for (let column = pivot; column <= size; column += 1) {
+        augmented[row][column] -= factor * augmented[pivot][column];
+      }
+    }
+  }
+
+  return augmented.map((row) => row[size]);
+}
+
+function fitPolynomial(points: XYPoint[], degree: number): number[] | null {
+  const deduped = collapseDuplicateX(points);
+
+  if (deduped.length < degree + 1) {
+    return null;
+  }
+
+  const matrixSize = degree + 1;
+  const sums = Array.from({ length: degree * 2 + 1 }, () => 0);
+  const rhs = Array.from({ length: matrixSize }, () => 0);
+
+  for (const point of deduped) {
+    const powers = Array.from({ length: degree * 2 + 1 }, (_, index) => point.x ** index);
+    for (let power = 0; power < powers.length; power += 1) {
+      sums[power] += powers[power];
+    }
+    for (let row = 0; row < matrixSize; row += 1) {
+      rhs[row] += point.y * powers[row];
+    }
+  }
+
+  const matrix = Array.from({ length: matrixSize }, (_, row) =>
+    Array.from({ length: matrixSize }, (_, column) => sums[row + column]),
+  );
+
+  return solveLinearSystem(matrix, rhs);
+}
+
+function evaluatePolynomial(coefficients: number[], x: number): number {
+  return coefficients.reduce((sum, coefficient, index) => sum + coefficient * x ** index, 0);
+}
+
+function buildPolynomialSeries(points: XYPoint[], degree: number, sampleCount = 100): XYPoint[] {
+  const coefficients = fitPolynomial(points, degree);
+  const deduped = collapseDuplicateX(points);
+
+  if (!coefficients || deduped.length === 0) {
+    return [];
+  }
+
+  const minX = deduped[0].x;
+  const maxX = deduped[deduped.length - 1].x;
+  if (Math.abs(maxX - minX) < 1e-10) {
+    return [{ x: minX, y: evaluatePolynomial(coefficients, minX) }];
+  }
+
+  return Array.from({ length: sampleCount }, (_, index) => {
+    const x = minX + ((maxX - minX) * index) / (sampleCount - 1);
+    return { x, y: evaluatePolynomial(coefficients, x) };
+  });
+}
+
+function fitNaturalCubicSpline(points: XYPoint[]): SplineSegment[] | null {
+  const deduped = collapseDuplicateX(points);
+
+  if (deduped.length < 2) {
+    return null;
+  }
+
+  if (deduped.length === 2) {
+    const [first, second] = deduped;
+    const slope = (second.y - first.y) / (second.x - first.x);
+    return [{
+      x0: first.x,
+      x1: second.x,
+      a: first.y,
+      b: slope,
+      c: 0,
+      d: 0,
+    }];
+  }
+
+  const pointCount = deduped.length;
+  const h = Array.from({ length: pointCount - 1 }, (_, index) => deduped[index + 1].x - deduped[index].x);
+  if (h.some((value) => value <= 0)) {
+    return null;
+  }
+
+  const alpha = Array.from({ length: pointCount }, () => 0);
+  for (let index = 1; index < pointCount - 1; index += 1) {
+    alpha[index] =
+      (3 / h[index]) * (deduped[index + 1].y - deduped[index].y) -
+      (3 / h[index - 1]) * (deduped[index].y - deduped[index - 1].y);
+  }
+
+  const l = Array.from({ length: pointCount }, () => 0);
+  const mu = Array.from({ length: pointCount }, () => 0);
+  const z = Array.from({ length: pointCount }, () => 0);
+  const c = Array.from({ length: pointCount }, () => 0);
+  const b = Array.from({ length: pointCount - 1 }, () => 0);
+  const d = Array.from({ length: pointCount - 1 }, () => 0);
+
+  l[0] = 1;
+  for (let index = 1; index < pointCount - 1; index += 1) {
+    l[index] = 2 * (deduped[index + 1].x - deduped[index - 1].x) - h[index - 1] * mu[index - 1];
+    if (Math.abs(l[index]) < 1e-10) {
+      return null;
+    }
+    mu[index] = h[index] / l[index];
+    z[index] = (alpha[index] - h[index - 1] * z[index - 1]) / l[index];
+  }
+  l[pointCount - 1] = 1;
+
+  const segments: SplineSegment[] = [];
+  for (let index = pointCount - 2; index >= 0; index -= 1) {
+    c[index] = z[index] - mu[index] * c[index + 1];
+    b[index] =
+      (deduped[index + 1].y - deduped[index].y) / h[index] -
+      (h[index] * (c[index + 1] + 2 * c[index])) / 3;
+    d[index] = (c[index + 1] - c[index]) / (3 * h[index]);
+
+    segments.unshift({
+      x0: deduped[index].x,
+      x1: deduped[index + 1].x,
+      a: deduped[index].y,
+      b: b[index],
+      c: c[index],
+      d: d[index],
+    });
+  }
+
+  return segments;
+}
+
+function evaluateSpline(segment: SplineSegment, x: number): number {
+  const delta = x - segment.x0;
+  return segment.a + segment.b * delta + segment.c * delta ** 2 + segment.d * delta ** 3;
+}
+
+function buildSplineSeries(points: XYPoint[], samplesPerSegment = 16): XYPoint[] {
+  const segments = fitNaturalCubicSpline(points);
+  if (!segments) {
+    return [];
+  }
+
+  const sampled: XYPoint[] = [];
+  for (const segment of segments) {
+    for (let index = 0; index < samplesPerSegment; index += 1) {
+      const x = segment.x0 + ((segment.x1 - segment.x0) * index) / samplesPerSegment;
+      sampled.push({ x, y: evaluateSpline(segment, x) });
+    }
+  }
+
+  const lastSegment = segments[segments.length - 1];
+  sampled.push({ x: lastSegment.x1, y: evaluateSpline(lastSegment, lastSegment.x1) });
+  return sampled;
+}
+
+export function buildChartData(
+  actualPoints: Record<string, XYPoint[]>,
+  fitPoints: Record<string, XYPoint[]>,
+): ChartPoint[] {
+  const merged = new Map<string, ChartPoint>();
+
+  const insertPoint = (distance: number, key: string, value: number) => {
+    const mapKey = distance.toFixed(6);
+    const existing = merged.get(mapKey) ?? { distance };
+    existing[key] = value;
+    merged.set(mapKey, existing);
+  };
+
+  for (const [key, points] of Object.entries(actualPoints)) {
+    for (const point of points) {
+      insertPoint(point.x, key, point.y);
+    }
+  }
+
+  for (const [key, points] of Object.entries(fitPoints)) {
+    for (const point of points) {
+      insertPoint(point.x, key, point.y);
+    }
+  }
+
+  return [...merged.values()].sort((a, b) => a.distance - b.distance);
+}
+
+export function buildQuadraticSeries(points: XYPoint[]): XYPoint[] {
+  return buildPolynomialSeries(points, 2);
+}
+
+export function buildCubicSeries(points: XYPoint[]): XYPoint[] {
+  return buildPolynomialSeries(points, 3);
+}
+
+export function buildSplineInterpolationSeries(points: XYPoint[]): XYPoint[] {
+  return buildSplineSeries(points);
+}


### PR DESCRIPTION
This is a change in the `settings_gui` app only; it adds [recharts](https://recharts.github.io/) based visualizations to display the shot maps.