### PR TITLE
Add configurable shot tuning distance source

### DIFF
--- a/settings_gui/src/components/shot-tuning/AttemptsList.tsx
+++ b/settings_gui/src/components/shot-tuning/AttemptsList.tsx
@@ -10,6 +10,7 @@ import {
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import type { TuningAttempt } from '../../types/ShotTuning';
+import { getAttemptDistanceSource, getAttemptSampleDistance } from '../../types/ShotTuning';
 
 interface AttemptsListProps {
   attempts: TuningAttempt[];
@@ -44,8 +45,13 @@ export function AttemptsList({ attempts, selectedId, onSelect, onDelete }: Attem
                 primary={
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                     <Typography variant="body2">
-                      {attempt.distanceMeters.toFixed(2)}m
+                      {getAttemptSampleDistance(attempt).toFixed(2)}m
                     </Typography>
+                    <Chip
+                      label={getAttemptDistanceSource(attempt) === 'networkTables' ? 'NT' : 'Odom'}
+                      size="small"
+                      variant="outlined"
+                    />
                     {attempt.flightTimeSec !== null && (
                       <Chip label={`${attempt.flightTimeSec.toFixed(3)}s`} size="small" color="primary" variant="outlined" />
                     )}

--- a/settings_gui/src/components/shot-tuning/TelemetryDisplay.tsx
+++ b/settings_gui/src/components/shot-tuning/TelemetryDisplay.tsx
@@ -1,17 +1,21 @@
 import { Box, Typography } from '@mui/material';
 import type { Telemetry } from '../../services/nt4';
+import CheckIcon from '@mui/icons-material/Check';
+import type { DistanceSource, TargetCoordinates } from '../../types/ShotTuning';
 
 interface TelemetryDisplayProps {
   telemetry: Telemetry;
+  distanceSource: DistanceSource;
+  targetCoordinates: TargetCoordinates;
 }
 
 function fmt(value: number, decimals = 3): string {
   return value.toFixed(decimals);
 }
 
-export function TelemetryDisplay({ telemetry }: TelemetryDisplayProps) {
+export function TelemetryDisplay({ telemetry, distanceSource, targetCoordinates }: TelemetryDisplayProps) {
   const ntDist = telemetry.distanceToHubMeters;
-  const poseDist = telemetry.distanceMeters;
+  const odometryDist = telemetry.distanceMeters;
 
   return (
     <Box>
@@ -19,13 +23,21 @@ export function TelemetryDisplay({ telemetry }: TelemetryDisplayProps) {
         Live Telemetry
       </Typography>
       <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 0.5 }}>
-        <Typography variant="body2" color="text.secondary">Distance to Hub:</Typography>
-        <Typography variant="body2" fontFamily="monospace">
+        <Typography variant="body2" color="text.secondary">NetworkTables Distance:</Typography>
+        <Typography variant="body2" fontFamily="monospace" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
           {ntDist !== null ? fmt(ntDist) : '--'} m
-          {' '}
-          <Typography component="span" variant="caption" color="text.secondary">
-            (pose: {fmt(poseDist)} m)
-          </Typography>
+          {distanceSource === 'networkTables' && <CheckIcon color="success" sx={{ fontSize: 20 }} />}
+        </Typography>
+
+        <Typography variant="body2" color="text.secondary">Odometry Distance:</Typography>
+        <Typography variant="body2" fontFamily="monospace" sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          {fmt(odometryDist)} m
+          {distanceSource === 'odometry' && <CheckIcon color="success" sx={{ fontSize: 20 }} />}
+        </Typography>
+
+        <Typography variant="body2" color="text.secondary">Target (x, y):</Typography>
+        <Typography variant="body2" fontFamily="monospace">
+          ({fmt(targetCoordinates.x)}, {fmt(targetCoordinates.y)})
         </Typography>
 
         <Typography variant="body2" color="text.secondary">Shooter Setpoint:</Typography>

--- a/settings_gui/src/components/shot-tuning/VideoReplayPlayer.tsx
+++ b/settings_gui/src/components/shot-tuning/VideoReplayPlayer.tsx
@@ -12,6 +12,7 @@ import {
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import PauseIcon from '@mui/icons-material/Pause';
 import type { TuningAttempt } from '../../types/ShotTuning';
+import { getAttemptDistanceSource, getAttemptSampleDistance, getAttemptTargetCoordinates } from '../../types/ShotTuning';
 import type { ShotMaps, ShotMapDataPoint } from '../../types/ShotMaps';
 import { clipUrl } from '../../services/shotTuningStorage';
 import { loadLocal, saveLocal } from '../../services/api';
@@ -36,6 +37,9 @@ export function VideoReplayPlayer({ attempt, onUpdate, attempts, onAttemptsChang
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
   const [exportError, setExportError] = useState<string | null>(null);
+  const sampleDistance = getAttemptSampleDistance(attempt);
+  const distanceSource = getAttemptDistanceSource(attempt);
+  const targetCoordinates = getAttemptTargetCoordinates(attempt);
 
 
   // Webm files often report wrong duration until fully buffered.
@@ -180,9 +184,8 @@ export function VideoReplayPlayer({ attempt, onUpdate, attempts, onAttemptsChang
   const handleExport = async (target: 'hub' | 'pass') => {
     if (attempt.flightTimeSec === null) return;
     setExportError(null);
-    const distance = attempt.distanceToHubMeters ?? attempt.distanceMeters;
     const newPoint: ShotMapDataPoint = {
-      distance: { value: distance, unit: 'Meter' },
+      distance: { value: sampleDistance, unit: 'Meter' },
       shooterRPM: attempt.shooterRPM,
       hoodAngle: { value: attempt.hoodAngleDegrees, unit: 'Degree' },
       flightTime: { value: attempt.flightTimeSec, unit: 'Second' },
@@ -332,12 +335,20 @@ export function VideoReplayPlayer({ attempt, onUpdate, attempts, onAttemptsChang
       <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 0.25, mb: 1 }}>
         <Typography variant="caption" color="text.secondary">Distance:</Typography>
         <Typography variant="caption" fontFamily="monospace">
-          {(attempt.distanceToHubMeters ?? attempt.distanceMeters).toFixed(3)} m
-          {attempt.distanceToHubMeters !== null && (
-            <Typography component="span" variant="caption" color="text.secondary">
-              {' '}(pose: {attempt.distanceMeters.toFixed(3)} m)
-            </Typography>
-          )}
+          {sampleDistance.toFixed(3)} m
+          <Typography component="span" variant="caption" color="text.secondary">
+            {' '}({distanceSource === 'networkTables' ? 'NetworkTables' : 'Odometry'})
+          </Typography>
+        </Typography>
+        <Typography variant="caption" color="text.secondary">NetworkTables:</Typography>
+        <Typography variant="caption" fontFamily="monospace">
+          {attempt.distanceToHubMeters !== null ? `${attempt.distanceToHubMeters.toFixed(3)} m` : '-- m'}
+        </Typography>
+        <Typography variant="caption" color="text.secondary">Odometry:</Typography>
+        <Typography variant="caption" fontFamily="monospace">{attempt.distanceMeters.toFixed(3)} m</Typography>
+        <Typography variant="caption" color="text.secondary">Target (x, y):</Typography>
+        <Typography variant="caption" fontFamily="monospace">
+          ({targetCoordinates.x.toFixed(3)}, {targetCoordinates.y.toFixed(3)})
         </Typography>
         <Typography variant="caption" color="text.secondary">Shooter:</Typography>
         <Typography variant="caption" fontFamily="monospace">{attempt.shooterRPM.toFixed(1)} RPM</Typography>

--- a/settings_gui/src/pages/ShotMapTuning.tsx
+++ b/settings_gui/src/pages/ShotMapTuning.tsx
@@ -6,8 +6,14 @@ import {
   Snackbar,
   Paper,
   Grid,
+  Stack,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
 } from '@mui/material';
-import type { TuningAttempt } from '../types/ShotTuning';
+import CheckIcon from '@mui/icons-material/Check';
+import type { DistanceSource, TargetCoordinates, TuningAttempt } from '../types/ShotTuning';
+import { DEFAULT_DISTANCE_SOURCE, DEFAULT_TARGET_COORDINATES } from '../types/ShotTuning';
 import { loadAttempts, saveAttempts, uploadClip, deleteClip } from '../services/shotTuningStorage';
 import { loadLocal } from '../services/api';
 import { NTConnectionStatus } from '../components/shot-tuning/NTConnectionStatus';
@@ -23,13 +29,46 @@ interface RobotInfo {
   robotToShooter: { translation: { x: number; y: number; z: number } };
 }
 
+interface DistanceSettings {
+  distanceSource: DistanceSource;
+  targetCoordinates: TargetCoordinates;
+}
+
+const DISTANCE_SETTINGS_STORAGE_KEY = 'shot-map-tuning.distance-settings';
+
+function loadDistanceSettings(): DistanceSettings {
+  try {
+    const raw = localStorage.getItem(DISTANCE_SETTINGS_STORAGE_KEY);
+    if (!raw) {
+      return {
+        distanceSource: DEFAULT_DISTANCE_SOURCE,
+        targetCoordinates: DEFAULT_TARGET_COORDINATES,
+      };
+    }
+    const parsed = JSON.parse(raw) as Partial<DistanceSettings>;
+    const source = parsed.distanceSource === 'odometry' ? 'odometry' : DEFAULT_DISTANCE_SOURCE;
+    const x = typeof parsed.targetCoordinates?.x === 'number' ? parsed.targetCoordinates.x : DEFAULT_TARGET_COORDINATES.x;
+    const y = typeof parsed.targetCoordinates?.y === 'number' ? parsed.targetCoordinates.y : DEFAULT_TARGET_COORDINATES.y;
+    return {
+      distanceSource: source,
+      targetCoordinates: { x, y },
+    };
+  } catch {
+    return {
+      distanceSource: DEFAULT_DISTANCE_SOURCE,
+      targetCoordinates: DEFAULT_TARGET_COORDINATES,
+    };
+  }
+}
+
 export function ShotMapTuning() {
   const { environment } = useConnection();
   const [attempts, setAttempts] = useState<TuningAttempt[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [snack, setSnack] = useState<{ message: string; severity: 'success' | 'error' } | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const shooterOffsetRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+  const [distanceSettings, setDistanceSettings] = useState<DistanceSettings>(loadDistanceSettings);
+  const [shooterOffset, setShooterOffset] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
   const [telemetry, setTelemetry] = useState<Telemetry>({
     distanceMeters: 0,
     distanceToHubMeters: null,
@@ -44,6 +83,11 @@ export function ShotMapTuning() {
   telemetryRef.current = telemetry;
   // Snapshot taken at the moment the user presses "Start Recording"
   const startSnapshotRef = useRef<Telemetry>(telemetry);
+  const startDistanceSettingsRef = useRef<DistanceSettings>(distanceSettings);
+
+  useEffect(() => {
+    localStorage.setItem(DISTANCE_SETTINGS_STORAGE_KEY, JSON.stringify(distanceSettings));
+  }, [distanceSettings]);
 
   const fetchAttempts = useCallback(async () => {
     try {
@@ -61,7 +105,7 @@ export function ShotMapTuning() {
     loadLocal<RobotInfo>(environment, 'RobotInfo.json')
       .then((info) => {
         const { x, y } = info.robotToShooter.translation;
-        shooterOffsetRef.current = { x, y };
+        setShooterOffset({ x, y });
       })
       .catch(() => { /* keep default {0,0} if unavailable */ });
   }, [environment]);
@@ -70,10 +114,13 @@ export function ShotMapTuning() {
     if (nt4Ref.current) {
       nt4Ref.current.disconnect();
     }
-    const svc = await createNT4Service(address, setTelemetry, shooterOffsetRef.current);
+    const svc = await createNT4Service(address, setTelemetry, {
+      shooterOffset,
+      targetCoordinates: distanceSettings.targetCoordinates,
+    });
     nt4Ref.current = svc;
     return svc;
-  }, []);
+  }, [distanceSettings.targetCoordinates, shooterOffset]);
 
   const handleDisconnect = useCallback(() => {
     if (nt4Ref.current) {
@@ -88,18 +135,33 @@ export function ShotMapTuning() {
     };
   }, []);
 
+  useEffect(() => {
+    nt4Ref.current?.updateDistanceConfig({
+      shooterOffset,
+      targetCoordinates: distanceSettings.targetCoordinates,
+    });
+  }, [distanceSettings.targetCoordinates, shooterOffset]);
+
   const handleRecordStart = useCallback(() => {
     startSnapshotRef.current = telemetryRef.current;
-  }, []);
+    startDistanceSettingsRef.current = distanceSettings;
+  }, [distanceSettings]);
 
   const handleStore = useCallback(async (blob: Blob) => {
     const id = crypto.randomUUID();
     const snap = startSnapshotRef.current;
+    const settingsAtStart = startDistanceSettingsRef.current;
+    const sampleDistanceMeters = settingsAtStart.distanceSource === 'networkTables'
+      ? snap.distanceToHubMeters ?? snap.distanceMeters
+      : snap.distanceMeters;
     const attempt: TuningAttempt = {
       id,
       createdAt: new Date().toISOString(),
       distanceMeters: snap.distanceMeters,
       distanceToHubMeters: snap.distanceToHubMeters,
+      sampleDistanceMeters,
+      distanceSource: settingsAtStart.distanceSource,
+      targetCoordinates: settingsAtStart.targetCoordinates,
       shooterRPM: snap.shooterRPM,
       hoodAngleDegrees: snap.hoodAngleDegrees,
       robotPoseX: snap.robotPoseX,
@@ -120,7 +182,7 @@ export function ShotMapTuning() {
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to store attempt');
     }
-  }, [attempts]);
+  }, [attempts, recordingFps]);
 
   const handleDelete = useCallback(async (id: string) => {
     try {
@@ -162,7 +224,108 @@ export function ShotMapTuning() {
         {/* Left column: Recording */}
         <Grid size={{ xs: 12, md: 6 }}>
           <Paper sx={{ p: 2, mb: 2 }}>
-            <TelemetryDisplay telemetry={telemetry} />
+            <Stack spacing={2}>
+              <Box>
+                <ToggleButtonGroup
+                  value={distanceSettings.distanceSource}
+                  exclusive
+                  onChange={(_, value: DistanceSource | null) => {
+                    if (!value) return;
+                    setDistanceSettings((current) => ({
+                      ...current,
+                      distanceSource: value,
+                    }));
+                  }}
+                  size="small"
+                >
+                  <ToggleButton value="networkTables">
+                    {distanceSettings.distanceSource === 'networkTables' && <CheckIcon fontSize="small" sx={{ mr: 0.5 }} />}
+                    Read dist from NT
+                  </ToggleButton>
+                  <ToggleButton value="odometry">
+                    {distanceSettings.distanceSource === 'odometry' && <CheckIcon fontSize="small" sx={{ mr: 0.5 }} />}
+                    Compute distance via Odometry
+                  </ToggleButton>
+                </ToggleButtonGroup>
+              </Box>
+
+              {distanceSettings.distanceSource === 'odometry' && (
+                <Box>
+                  <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ xs: 'stretch', sm: 'center' }}>
+                    <TextField
+                      label="Target X (m)"
+                      type="number"
+                      value={distanceSettings.targetCoordinates.x}
+                      onChange={(event) => {
+                        const value = Number.parseFloat(event.target.value);
+                        setDistanceSettings((current) => ({
+                          ...current,
+                          targetCoordinates: {
+                            ...current.targetCoordinates,
+                            x: Number.isFinite(value) ? value : 0,
+                          },
+                        }));
+                      }}
+                      inputProps={{ step: '0.1' }}
+                      size="small"
+                      fullWidth
+                    />
+                    <TextField
+                      label="Target Y (m)"
+                      type="number"
+                      value={distanceSettings.targetCoordinates.y}
+                      onChange={(event) => {
+                        const value = Number.parseFloat(event.target.value);
+                        setDistanceSettings((current) => ({
+                          ...current,
+                          targetCoordinates: {
+                            ...current.targetCoordinates,
+                            y: Number.isFinite(value) ? value : 0,
+                          },
+                        }));
+                      }}
+                      inputProps={{ step: '0.1' }}
+                      size="small"
+                      fullWidth
+                    />
+                    <Box sx={{ display: 'flex', justifyContent: { xs: 'flex-start', sm: 'center' } }}>
+                      <Typography
+                        component="button"
+                        type="button"
+                        onClick={() => {
+                          setDistanceSettings((current) => ({
+                            ...current,
+                            targetCoordinates: { ...DEFAULT_TARGET_COORDINATES },
+                          }));
+                        }}
+                        sx={{
+                          border: 'none',
+                          background: 'none',
+                          p: 0,
+                          m: 0,
+                          color: 'primary.main',
+                          cursor: 'pointer',
+                          font: 'inherit',
+                          fontSize: '0.75rem',
+                          textDecoration: 'underline',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        reset to
+                        <br />
+                        hub coords
+                      </Typography>
+                    </Box>
+                  </Stack>
+                </Box>
+              )}
+
+              <TelemetryDisplay
+                telemetry={telemetry}
+                distanceSource={distanceSettings.distanceSource}
+                targetCoordinates={distanceSettings.targetCoordinates}
+              />
+            </Stack>
           </Paper>
 
           <Paper sx={{ p: 2, mb: 2 }}>

--- a/settings_gui/src/services/nt4.ts
+++ b/settings_gui/src/services/nt4.ts
@@ -1,9 +1,14 @@
-import { HUB_CENTER } from '../types/ShotTuning';
+import type { TargetCoordinates } from '../types/ShotTuning';
+
+export interface DistanceConfig {
+  shooterOffset: { x: number; y: number };
+  targetCoordinates: TargetCoordinates;
+}
 
 export interface Telemetry {
-  /** Pose-computed distance to hub (meters) */
+  /** Pose-computed distance to the configured target (meters) */
   distanceMeters: number;
-  /** NT-reported distance to hub from robot (meters); null until first value received */
+  /** NT-reported distance from the robot (meters); null until first value received */
   distanceToHubMeters: number | null;
   /** Shooter setpoint in RPM (from TunableNumbers) */
   shooterRPM: number;
@@ -17,6 +22,7 @@ export interface NT4Service {
   disconnect(): void;
   addConnectionListener(cb: (connected: boolean) => void): () => void;
   isConnected(): boolean;
+  updateDistanceConfig(config: DistanceConfig): void;
 }
 
 // AdvantageKit publishes Logger.recordOutput / @AutoLogOutput under this prefix.
@@ -36,7 +42,7 @@ const TOPIC_DISTANCE_HUB = `${AK_PREFIX}/CoordinationLayer/distanceToHub`;      
 export async function createNT4Service(
   address: string,
   onTelemetry: (update: Telemetry) => void,
-  shooterOffset: { x: number; y: number } = { x: 0, y: 0 },
+  initialDistanceConfig: DistanceConfig,
 ): Promise<NT4Service> {
   const { decodeMulti } = await import('@msgpack/msgpack');
 
@@ -46,13 +52,15 @@ export async function createNT4Service(
   let shooterRPM = 0;
   let hoodAngleDegrees = 0;
   let distanceToHubMeters: number | null = null;
+  let distanceConfig = initialDistanceConfig;
 
   function emitUpdate() {
     // Rotate the robot-frame shooter offset into field frame using the robot heading.
+    const { shooterOffset, targetCoordinates } = distanceConfig;
     const shooterX = poseX + shooterOffset.x * Math.cos(poseHeading) - shooterOffset.y * Math.sin(poseHeading);
     const shooterY = poseY + shooterOffset.x * Math.sin(poseHeading) + shooterOffset.y * Math.cos(poseHeading);
-    const dx = shooterX - HUB_CENTER.x;
-    const dy = shooterY - HUB_CENTER.y;
+    const dx = shooterX - targetCoordinates.x;
+    const dy = shooterY - targetCoordinates.y;
     onTelemetry({
       distanceMeters: Math.sqrt(dx * dx + dy * dy),
       distanceToHubMeters,
@@ -196,6 +204,10 @@ export async function createNT4Service(
     },
     isConnected() {
       return connected;
+    },
+    updateDistanceConfig(config: DistanceConfig) {
+      distanceConfig = config;
+      emitUpdate();
     },
   };
 }

--- a/settings_gui/src/types/ShotTuning.ts
+++ b/settings_gui/src/types/ShotTuning.ts
@@ -1,10 +1,23 @@
+export type DistanceSource = 'networkTables' | 'odometry';
+
+export interface TargetCoordinates {
+  x: number;
+  y: number;
+}
+
 export interface TuningAttempt {
   id: string;
   createdAt: string;
-  /** Distance computed from robot pose vs hub center (meters) */
+  /** Distance computed from robot pose vs the configured target (meters) */
   distanceMeters: number;
-  /** Distance reported directly by the robot via NT (meters); null for old attempts */
+  /** Distance reported directly by the robot via NT (meters); retained field name for compatibility */
   distanceToHubMeters: number | null;
+  /** Distance recorded for this sample based on the selected source at capture time */
+  sampleDistanceMeters?: number;
+  /** Source selected when this sample was captured */
+  distanceSource?: DistanceSource;
+  /** Target coordinates used when computing the odometry distance */
+  targetCoordinates?: TargetCoordinates;
   /** Shooter setpoint in RPM (from TunableNumbers) */
   shooterRPM: number;
   /** Hood setpoint in degrees (from TunableNumbers) */
@@ -18,11 +31,27 @@ export interface TuningAttempt {
   fps: number;
 }
 
-// 
-// coordinates below were obtained via FieldConstants.Hub.oppInnerCenterPoint(); 
-// (red hub, blue origin)
-// - gback
-export const HUB_CENTER = { 
-    x: 11.894744,
-    y: 4.021500
-} as const;
+// Coordinates below were obtained via FieldConstants.Hub.oppInnerCenterPoint().
+// This remains the default target so existing hub tuning behavior is unchanged.
+export const DEFAULT_TARGET_COORDINATES = {
+  x: 11.894744,
+  y: 4.021500,
+} as const satisfies TargetCoordinates;
+
+export const DEFAULT_DISTANCE_SOURCE: DistanceSource = 'networkTables';
+
+export function getAttemptDistanceSource(attempt: TuningAttempt): DistanceSource {
+  if (attempt.distanceSource) return attempt.distanceSource;
+  return attempt.distanceToHubMeters !== null ? 'networkTables' : 'odometry';
+}
+
+export function getAttemptTargetCoordinates(attempt: TuningAttempt): TargetCoordinates {
+  return attempt.targetCoordinates ?? DEFAULT_TARGET_COORDINATES;
+}
+
+export function getAttemptSampleDistance(attempt: TuningAttempt): number {
+  if (attempt.sampleDistanceMeters !== undefined) return attempt.sampleDistanceMeters;
+  return getAttemptDistanceSource(attempt) === 'networkTables'
+    ? attempt.distanceToHubMeters ?? attempt.distanceMeters
+    : attempt.distanceMeters;
+}


### PR DESCRIPTION
There are now 2 choices:

- read from network tables - this reads the distanceToHub published in test mode
- read from odometry - allows you to specify the coordinates. Initialized (and resettable) to hub coordinates. Should be remembered in localStorage across reloads.

The currently active choice has a green checkmark next to it, and this choice is captured and added to the attempts column on the right. Otherwise the app should work as before @thetaback