### PR TITLE
(#149) updated photonlib to v2026.3.2 and akit to v2026.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,7 @@ dependencies {
     def akitJson = new groovy.json.JsonSlurper().parseText(new File(projectDir.getAbsolutePath() + "/vendordeps/AdvantageKit.json").text)
     annotationProcessor "org.littletonrobotics.akit:akit-autolog:$akitJson.version"
 
-    def coppercoreVersion = "2026.2.19"
+    def coppercoreVersion = "2026.2.20"
 
     implementation "com.google.code.gson:gson:2.11.0"
 

--- a/vendordeps/AdvantageKit.json
+++ b/vendordeps/AdvantageKit.json
@@ -1,7 +1,7 @@
 {
   "fileName": "AdvantageKit.json",
   "name": "AdvantageKit",
-  "version": "26.0.0",
+  "version": "26.0.2",
   "uuid": "d820cc26-74e3-11ec-90d6-0242ac120003",
   "frcYear": "2026",
   "mavenUrls": [
@@ -12,14 +12,14 @@
     {
       "groupId": "org.littletonrobotics.akit",
       "artifactId": "akit-java",
-      "version": "26.0.0"
+      "version": "26.0.2"
     }
   ],
   "jniDependencies": [
     {
       "groupId": "org.littletonrobotics.akit",
       "artifactId": "akit-wpilibio",
-      "version": "26.0.0",
+      "version": "26.0.2",
       "skipInvalidPlatforms": false,
       "isJar": false,
       "validPlatforms": [

--- a/vendordeps/photonlib.json
+++ b/vendordeps/photonlib.json
@@ -1,7 +1,7 @@
 {
   "fileName": "photonlib.json",
   "name": "photonlib",
-  "version": "v2026.2.2",
+  "version": "v2026.3.2",
   "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004",
   "frcYear": "2026",
   "mavenUrls": [
@@ -13,7 +13,7 @@
     {
       "groupId": "org.photonvision",
       "artifactId": "photontargeting-cpp",
-      "version": "v2026.2.2",
+      "version": "v2026.3.2",
       "skipInvalidPlatforms": true,
       "isJar": false,
       "validPlatforms": [
@@ -28,7 +28,7 @@
     {
       "groupId": "org.photonvision",
       "artifactId": "photonlib-cpp",
-      "version": "v2026.2.2",
+      "version": "v2026.3.2",
       "libName": "photonlib",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -43,7 +43,7 @@
     {
       "groupId": "org.photonvision",
       "artifactId": "photontargeting-cpp",
-      "version": "v2026.2.2",
+      "version": "v2026.3.2",
       "libName": "photontargeting",
       "headerClassifier": "headers",
       "sharedLibrary": true,
@@ -60,12 +60,12 @@
     {
       "groupId": "org.photonvision",
       "artifactId": "photonlib-java",
-      "version": "v2026.2.2"
+      "version": "v2026.3.2"
     },
     {
       "groupId": "org.photonvision",
       "artifactId": "photontargeting-java",
-      "version": "v2026.2.2"
+      "version": "v2026.3.2"
     }
   ]
 }


### PR DESCRIPTION
Also updated coppercore to 2026.2.20 (which as of now doesn't exist, so this will fail CI at first).